### PR TITLE
add download watcher

### DIFF
--- a/calibre-plugin/config.py
+++ b/calibre-plugin/config.py
@@ -97,6 +97,8 @@ class PreferenceKeys:
     CACHE_AGE_DAYS = "cache_age_days"
     SEARCH_MODE = "search_mode"
     DISABLE_TAB_MAGAZINES = "disable_tab_magazines"
+    DOWNLOADS_FOLDER = "downloads_folder"
+    USE_BROWSER_DOWNLOAD = "use_browser_download"
 
 
 class BorrowActions:
@@ -141,6 +143,8 @@ class PreferenceTexts:
     USE_BEST_COVER = _("Use highest-resolution cover for book details")
     CACHE_AGE_DAYS = _("Cache data for")
     DISABLE_TAB_MAGAZINES = _("Disable Magazines tab")
+    DOWNLOADS_FOLDER = _("Downloads folder")
+    USE_BROWSER_DOWNLOAD = _("Use browser-assisted download")
 
 
 PREFS = JSONConfig(f"{PLUGINS_FOLDER_NAME}/{PLUGIN_NAME}")
@@ -178,6 +182,8 @@ PREFS.defaults[PreferenceKeys.MAGAZINE_SUBSCRIPTIONS] = []
 PREFS.defaults[PreferenceKeys.LAST_BORROW_ACTION] = BorrowActions.BORROW
 PREFS.defaults[PreferenceKeys.LAST_SELECTED_TAB] = 0
 PREFS.defaults[PreferenceKeys.SEARCH_MODE] = SearchMode.BASIC
+PREFS.defaults[PreferenceKeys.DOWNLOADS_FOLDER] = ""
+PREFS.defaults[PreferenceKeys.USE_BROWSER_DOWNLOAD] = True
 
 
 class ConfigWidget(QWidget):
@@ -653,6 +659,28 @@ class ConfigWidget(QWidget):
         )
         general_layout.addRow(self.disable_tab_magazines_checkbox)
 
+        # Use browser-assisted download
+        self.use_browser_download_checkbox = QCheckBox(
+            PreferenceTexts.USE_BROWSER_DOWNLOAD
+        )
+        self.use_browser_download_checkbox.setToolTip(
+            _("When enabled, the plugin will watch the downloads folder for the file after opening Libby in the browser.")
+        )
+        self.use_browser_download_checkbox.setChecked(
+            PREFS[PreferenceKeys.USE_BROWSER_DOWNLOAD]
+        )
+        general_layout.addRow(self.use_browser_download_checkbox)
+
+        # Downloads folder
+        self.downloads_folder_txt = QLineEdit(self)
+        self.downloads_folder_txt.setToolTip(
+            _("The folder where your browser saves downloaded files (e.g., .acsm or .epub).")
+        )
+        self.downloads_folder_txt.setPlaceholderText(_("Path to your Downloads folder"))
+        if not DEMO_MODE:
+            self.downloads_folder_txt.setText(PREFS[PreferenceKeys.DOWNLOADS_FOLDER])
+        general_layout.addRow(PreferenceTexts.DOWNLOADS_FOLDER, self.downloads_folder_txt)
+
         # Include non-downloadables
         self.incl_nondownloadable_checkbox = QCheckBox(
             PreferenceTexts.INCL_NONDOWNLOADABLE_TITLES
@@ -994,6 +1022,8 @@ class ConfigWidget(QWidget):
         PREFS[PreferenceKeys.CACHE_AGE_DAYS] = int(
             self.cache_age_txt.cleanText().strip()
         )
+        PREFS[PreferenceKeys.DOWNLOADS_FOLDER] = self.downloads_folder_txt.text().strip()
+        PREFS[PreferenceKeys.USE_BROWSER_DOWNLOAD] = self.use_browser_download_checkbox.isChecked()
 
         if self.custom_column_creator and (
             self.custom_column_creator.gui.must_restart_before_config

--- a/calibre-plugin/dialog/loans.py
+++ b/calibre-plugin/dialog/loans.py
@@ -174,9 +174,9 @@ class LoansDialogMixin(BaseDialogMixin):
 
         # Download button
         self.download_btn = DefaultQPushButton(
-            _c("Open in libbyapp.com"), self.resources[PluginImages.Download], self
+            _c("Download"), self.resources[PluginImages.Download], self
         )
-        self.download_btn.setToolTip(_("Open loan in libbyapp.com website"))
+        self.download_btn.setToolTip(_("Download loan to calibre (opens browser for fulfillment)"))
         self.download_btn.clicked.connect(self.download_btn_clicked)
         widget.layout.addWidget(
             self.download_btn,
@@ -371,12 +371,123 @@ class LoansDialogMixin(BaseDialogMixin):
         if selection_model.hasSelection():
             rows = selection_model.selectedRows()
             for row in reversed(rows):
-                self.openLibbyDownload(row.data(Qt.UserRole))
-                # self.download_loan(row.data(Qt.UserRole))
-                # if PREFS[PreferenceKeys.HIDE_BOOKS_ALREADY_IN_LIB]:
-                #     self.loans_search_proxy_model.temporarily_hide(
-                #         row.data(Qt.UserRole)
-                #     )
+                if PREFS.get(PreferenceKeys.USE_BROWSER_DOWNLOAD, True):
+                    self.browser_assisted_download(row.data(Qt.UserRole))
+                else:
+                    self.openLibbyDownload(row.data(Qt.UserRole))
+
+    def browser_assisted_download(self, loan):
+        downloads_folder = PREFS.get(PreferenceKeys.DOWNLOADS_FOLDER, "")
+        if not downloads_folder:
+            from calibre.gui2 import error_dialog
+            error_dialog(
+                self,
+                _("Downloads Folder Not Set"),
+                _("Please configure your Downloads folder in the plugin settings (General tab) to use browser-assisted downloading."),
+                show=True,
+            )
+            self.openLibbyDownload(loan)
+            return
+
+        from ..tools.WatchForFile import wait_for_file_qt
+        
+        try:
+            format_id = LibbyClient.get_loan_format(
+                loan, prefer_open_format=PREFS[PreferenceKeys.PREFER_OPEN_FORMATS]
+            )
+        except ValueError:
+            format_id = LibbyClient.get_locked_in_format(loan)
+            
+        expected_ext = LibbyClient.get_file_extension(format_id) if format_id else "acsm"
+        if not expected_ext.startswith("."):
+            expected_ext = f".{expected_ext}"
+            
+        libbyurl = f'https://libbyapp.com/shelf/loans/{loan["cardId"]}-{loan["id"]}/fulfill'
+        CustomLogger.log_simple_string(f"Opening {libbyurl} and watching {downloads_folder} for {expected_ext}")
+        open_url(libbyurl)
+
+        from qt.core import QProgressDialog, Qt
+        
+        progress = QProgressDialog(_("Waiting for download to finish in browser..."), _("Cancel"), 0, 0, self)
+        progress.setWindowTitle(_("Browser-Assisted Download"))
+        progress.setWindowModality(Qt.WindowModal)
+        progress.show()
+        
+        # Start watching
+        file_path = wait_for_file_qt(downloads_folder, expected_ext, cancel_callback=progress.wasCanceled)
+        progress.close()
+        
+        if file_path:
+            CustomLogger.log_simple_string(f"File found at {file_path}, importing...")
+            self.import_downloaded_file(loan, format_id, file_path)
+        else:
+            CustomLogger.log_simple_string("Download timed out or was canceled.")
+
+    def import_downloaded_file(self, loan, format_id, file_path):
+        from ..ebook_download import CustomEbookDownload
+        from ..magazine_download import CustomMagazineDownload
+        
+        # Figure out the tags
+        if LibbyClient.is_downloadable_magazine_loan(loan):
+            tags = [t.strip() for t in PREFS[PreferenceKeys.TAG_MAGAZINES].split(",")]
+            downloader = CustomMagazineDownload()
+        else:
+            tags = [t.strip() for t in PREFS[PreferenceKeys.TAG_EBOOKS].split(",")]
+            downloader = CustomEbookDownload()
+            
+        card = self.loans_model.get_card(loan["cardId"])
+        library = self.loans_model.get_library(self.loans_model.get_website_id(card))
+
+        book_id, metadata = self.match_existing_book(loan, library, format_id)
+            
+        description = _("Importing {format} for {book}").format(
+            format=LibbyClient.get_file_extension(format_id).upper(),
+            book=as_unicode(get_media_title(loan), errors="replace"),
+        )
+        
+        callback = Dispatcher(self.import_finished)
+        
+        from calibre.gui2.threaded_jobs import ThreadedJob
+        job = ThreadedJob(
+            "overdrive_libby_import",
+            description,
+            self._do_import_job,
+            (downloader, self.gui, loan, card, library, format_id, file_path, book_id, tags, metadata),
+            {},
+            callback,
+            max_concurrent_count=1,
+            killable=False,
+        )
+        self.gui.job_manager.run_threaded_job(job)
+        self.gui.status_bar.show_message(description, 3000)
+
+    def _do_import_job(self, downloader, gui, loan, card, library, format_id, file_path, book_id, tags, metadata, log=None, abort=None, notifications=None):
+        try:
+            downloader.add(
+                gui,
+                loan,
+                card,
+                library,
+                format_id,
+                file_path,
+                book_id,
+                tags,
+                metadata,
+            )
+        finally:
+            try:
+                file_path.unlink(missing_ok=True)
+            except Exception as e:
+                CustomLogger.logger.warning(f"Could not remove temp file: {e}")
+        return loan
+
+    def import_finished(self, job):
+        if job.failed:
+            return self.unhandled_exception(
+                job.exception, msg=_("Failed to import downloaded file")
+            )
+        self.loan_added.emit(job.result)
+        self.gui.status_bar.show_message(job.description + " " + _c("finished"), 5000)
 
     def openLibbyDownload(self, loan) :
         libbyurl = f'https://libbyapp.com/shelf/loans/{loan["cardId"]}-{loan["id"]}/fulfill'

--- a/calibre-plugin/dialog/loans.py
+++ b/calibre-plugin/dialog/loans.py
@@ -445,7 +445,7 @@ class LoansDialogMixin(BaseDialogMixin):
             book=as_unicode(get_media_title(loan), errors="replace"),
         )
         
-        callback = Dispatcher(self.import_finished)
+        callback = Dispatcher(self.downloaded_loan)
         
         from calibre.gui2.threaded_jobs import ThreadedJob
         job = ThreadedJob(
@@ -462,8 +462,9 @@ class LoansDialogMixin(BaseDialogMixin):
         self.gui.status_bar.show_message(description, 3000)
 
     def _do_import_job(self, downloader, gui, loan, card, library, format_id, file_path, book_id, tags, metadata, log=None, abort=None, notifications=None):
+        handled_asynchronously = False
         try:
-            downloader.add(
+            handled_asynchronously = downloader.add(
                 gui,
                 loan,
                 card,
@@ -475,19 +476,12 @@ class LoansDialogMixin(BaseDialogMixin):
                 metadata,
             )
         finally:
-            try:
-                file_path.unlink(missing_ok=True)
-            except Exception as e:
-                CustomLogger.logger.warning(f"Could not remove temp file: {e}")
+            if not handled_asynchronously:
+                try:
+                    file_path.unlink(missing_ok=True)
+                except Exception as e:
+                    CustomLogger.logger.warning(f"Could not remove temp file: {e}")
         return loan
-
-    def import_finished(self, job):
-        if job.failed:
-            return self.unhandled_exception(
-                job.exception, msg=_("Failed to import downloaded file")
-            )
-        self.loan_added.emit(job.result)
-        self.gui.status_bar.show_message(job.description + " " + _c("finished"), 5000)
 
     def openLibbyDownload(self, loan) :
         libbyurl = f'https://libbyapp.com/shelf/loans/{loan["cardId"]}-{loan["id"]}/fulfill'

--- a/calibre-plugin/download.py
+++ b/calibre-plugin/download.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Optional
 
 from calibre.ebooks.metadata.meta import get_metadata
 from calibre.ebooks.metadata.worker import run_import_plugins
+from calibre.gui2 import Dispatcher
 
 from .config import PREFS, PreferenceKeys
 from .libby import LibbyClient
@@ -182,7 +183,7 @@ class LibbyDownload:
         book_id: int = 0,
         tags: Optional[List[str]] = None,
         metadata=None,
-    ) -> None:
+    ) -> bool:
         """
         Adds the new downloaded book to calibre db
 
@@ -214,6 +215,29 @@ class LibbyDownload:
             )[0]
             new_ext = Path(new_path).suffix[1:]
 
+            if new_ext.lower() == "acsm":
+                # For ACSM files, we MUST use Calibre's standard Add Books action
+                # to ensure that FileType plugins like DeACSM are triggered correctly.
+                # Update metadata anyway since we matched it
+                metadata = self.update_metadata(gui, loan, library, format_id, metadata, tags)
+                db.set_metadata(book_id, metadata)
+                self.update_custom_columns(book_id, loan, db)
+                if PREFS[PreferenceKeys.MARK_UPDATED_BOOKS]:
+                    gui.current_db.set_marked_ids([book_id])
+                gui.library_view.model().refresh_ids([book_id])
+
+                def trigger_add():
+                    add_books_action = gui.iactions.get("Add Books")
+                    if add_books_action and hasattr(add_books_action, "_add_formats"):
+                        file_size = os.path.getsize(new_path) if os.path.exists(new_path) else -1
+                        CustomLogger.logger.info(f"Triggering _add_formats for {new_path} ({file_size} bytes)")
+                        add_books_action._add_formats([str(new_path)], [book_id])
+                    else:
+                        CustomLogger.logger.warning("Could not find _add_formats in Add Books action")
+                
+                Dispatcher(trigger_add)()
+                return True
+
             # if book_id is found, it's an empty book, download and add the epub/pdf as a format
             successfully_added = db.add_format(
                 book_id, new_ext.upper(), new_path, replace=False
@@ -233,6 +257,7 @@ class LibbyDownload:
                 if PREFS[PreferenceKeys.MARK_UPDATED_BOOKS]:
                     gui.current_db.set_marked_ids([book_id])  # mark updated book
                 gui.library_view.model().refresh_ids([book_id])
+
         else:
             # add as a new book
 
@@ -253,9 +278,30 @@ class LibbyDownload:
                 gui, loan, library, format_id, metadata, tags
             )
             book_id = gui.library_view.model().db.create_book_entry(metadata)
+            self.update_custom_columns(book_id, loan, db)
+
+            if new_ext.lower() == "acsm":
+                # For ACSM files, we MUST use Calibre's standard Add Books action
+                # to ensure that FileType plugins like DeACSM are triggered correctly.
+                
+                def trigger_add():
+                    add_books_action = gui.iactions.get("Add Books")
+                    if add_books_action and hasattr(add_books_action, "_add_formats"):
+                        file_size = os.path.getsize(new_path) if os.path.exists(new_path) else -1
+                        CustomLogger.logger.info(f"Triggering _add_formats for new book {new_path} ({file_size} bytes)")
+                        add_books_action._add_formats([str(new_path)], [book_id])
+                    else:
+                        CustomLogger.logger.warning("Could not find _add_formats in Add Books action")
+                
+                Dispatcher(trigger_add)()
+                gui.library_view.model().books_added(1)
+                gui.library_view.model().count_changed()
+                return True
+
             gui.library_view.model().db.add_format_with_hooks(
                 book_id, new_ext.upper(), new_path, index_is_id=True
             )
-            self.update_custom_columns(book_id, loan, db)
             gui.library_view.model().books_added(1)
             gui.library_view.model().count_changed()
+
+        return False

--- a/calibre-plugin/ebook_download.py
+++ b/calibre-plugin/ebook_download.py
@@ -47,7 +47,7 @@ class CustomEbookDownload(LibbyDownload):
     ):
         if not tags:
             tags = []
-        downloaded_filepath: Optional[Path] = None
+        handled_asynchronously = False
         try:
             downloaded_filepath = self._custom_download(
                 libby_client,
@@ -57,7 +57,7 @@ class CustomEbookDownload(LibbyDownload):
                 abort=abort,
                 notifications=notifications,
             )
-            self.add(
+            handled_asynchronously = self.add(
                 gui,
                 loan,
                 card,
@@ -70,11 +70,12 @@ class CustomEbookDownload(LibbyDownload):
             )
 
         finally:
-            try:
-                if downloaded_filepath:
-                    downloaded_filepath.unlink(missing_ok=True)
-            except:  # noqa
-                pass
+            if not handled_asynchronously:
+                try:
+                    if downloaded_filepath:
+                        downloaded_filepath.unlink(missing_ok=True)
+                except:  # noqa
+                    pass
         return loan
 
     def _custom_download(

--- a/calibre-plugin/tools/WatchForFile.py
+++ b/calibre-plugin/tools/WatchForFile.py
@@ -1,6 +1,8 @@
 import os
 import time
 import datetime
+import xml.etree.ElementTree as ET
+import zipfile
 from qt.core import QTimer, QEventLoop, QObject, pyqtSignal, QFileSystemWatcher
 from tempfile import gettempdir
 from shutil import move
@@ -65,6 +67,27 @@ class FileWaiter(QObject):
         self.timeout_timer.stop()
         self.watcher.removePath(self.folder)
                                 
+def is_file_ready(path: str, extension: str) -> bool:
+    """
+    Check if a file is ready for processing by validating its structure.
+    Returns True if valid, False otherwise.
+    """
+    try:
+        # Check if we can open for reading (handles Windows locks)
+        with open(path, 'rb') as f:
+            if extension.lower() == '.acsm':
+                # Validate XML structure
+                ET.parse(f)
+                return True
+            elif extension.lower() == '.epub':
+                # Validate ZIP structure
+                return zipfile.is_zipfile(path)
+            else:
+                # Default for other types: just ensure it's not empty
+                return os.path.getsize(path) > 0
+    except (IOError, OSError, ET.ParseError, zipfile.BadZipFile):
+        return False
+
 def wait_for_file_qt(folder : str, extension : str,  interval_ms = 500, timeout_ms=300000, cancel_callback=None) -> Optional[Path]:    # 300000 = 5 minutes
     loop = QEventLoop()
     waiter = FileWaiter(folder, extension, interval_ms , timeout_ms, cancel_callback)
@@ -85,14 +108,27 @@ def wait_for_file_qt(folder : str, extension : str,  interval_ms = 500, timeout_
     loop.exec_()
 
     file_path = result['path']
-    if file_path :
+    if file_path:
+        # Wait for file to be logically complete (valid XML/ZIP)
+        # Timeout after 60 seconds of existence if it never becomes valid
+        start_wait = time.time()
+        ready = False
+        while time.time() - start_wait < 60:
+            if is_file_ready(file_path, extension):
+                ready = True
+                break
+            time.sleep(0.1) # 100ms poll
+            
+        if not ready:
+            CustomLogger.log_simple_string(f"File {file_path} was found but never became valid (timeout).")
+            return None
 
         temp_path = os.path.join(gettempdir() , os.path.basename(file_path))
         print(f"Moving {file_path} to {temp_path}")
         move(file_path, temp_path)
 
         return Path(temp_path)
-    else :
+    else:
         return None
 
 

--- a/calibre-plugin/tools/WatchForFile.py
+++ b/calibre-plugin/tools/WatchForFile.py
@@ -13,11 +13,12 @@ class FileWaiter(QObject):
     timeout_reached = pyqtSignal()
   
 
-    def __init__(self, folder, extension, interval_ms, timeout_ms):
+    def __init__(self, folder, extension, interval_ms, timeout_ms, cancel_callback=None):
         super().__init__()
         self.folder = folder
         self.extension = extension
         self.start_time = time.time()
+        self.cancel_callback = cancel_callback
 
         self.watcher = QFileSystemWatcher([folder])
         self.watcher.directoryChanged.connect(self.check_for_file)
@@ -34,6 +35,10 @@ class FileWaiter(QObject):
         self.timeout_timer.start()
 
     def check_for_file(self):
+        if self.cancel_callback and self.cancel_callback():
+            self.handle_timeout()
+            return
+            
         self.extension = self.extension.lower()
         print(f"checking for {self.extension} in {self.folder}")
         for fname in os.listdir(self.folder):          
@@ -51,11 +56,6 @@ class FileWaiter(QObject):
                         startString   = datetime.datetime.fromtimestamp(self.start_time).strftime("%Y-%m-%d %H:%M:%S")
                         CustomLogger.log_simple_string(f"Ignoring pre-existing file {full_path} {createdString} before {startString}")
 
-
-
-
-
-
     def handle_timeout(self):
         self.timeout_reached.emit()
         self.cleanup()
@@ -65,9 +65,9 @@ class FileWaiter(QObject):
         self.timeout_timer.stop()
         self.watcher.removePath(self.folder)
                                 
-def wait_for_file_qt(folder : str, extension : str,  interval_ms = 500, timeout_ms=300000) -> Optional[Path]:    # 300000 = 5 minutes
+def wait_for_file_qt(folder : str, extension : str,  interval_ms = 500, timeout_ms=300000, cancel_callback=None) -> Optional[Path]:    # 300000 = 5 minutes
     loop = QEventLoop()
-    waiter = FileWaiter(folder, extension, interval_ms , timeout_ms)
+    waiter = FileWaiter(folder, extension, interval_ms , timeout_ms, cancel_callback)
 
     result = {}
 


### PR DESCRIPTION
Re-enables download button which redirects to a web browser.  File watcher waits for the downloaded file to land in the user's specified directory, then updates the calibre library.